### PR TITLE
CS-167: remove crypto from packages; it is now default node package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "author": "leelow",
   "license": "MIT",
   "dependencies": {
-    "crypto": "0.0.3",
     "request": "^2.72.0"
   }
 }


### PR DESCRIPTION
remove crypto 0.0.3 because it is now a core node package